### PR TITLE
Redux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,16 @@
         "@types/react": "16.0.25"
       }
     },
+    "@types/react-redux": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-5.0.13.tgz",
+      "integrity": "sha512-JC2uTBq74G1WRIdYlsd4qMSp4oZWcgYIKLecgHAglY85Nco4h1Ld3teqBUJQJMJq8Xh4SR83QFExUZX/TtIkww==",
+      "dev": true,
+      "requires": {
+        "@types/react": "16.0.25",
+        "redux": "3.7.2"
+      }
+    },
     "@types/react-router": {
       "version": "4.0.17",
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-4.0.17.tgz",
@@ -82,6 +92,26 @@
         "@types/history": "4.6.2",
         "@types/react": "16.0.25",
         "@types/react-router": "4.0.17"
+      }
+    },
+    "@types/react-router-redux": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react-router-redux/-/react-router-redux-5.0.10.tgz",
+      "integrity": "sha512-lnNV01T9OauPJMtKu2VDmXnviVMSHsIE621jxNiS69uFmQrQUGEwyR+BEGIZ1wCdvgERcVRqrQSNCjKOcNYFnw==",
+      "dev": true,
+      "requires": {
+        "@types/history": "4.6.2",
+        "@types/react": "16.0.25",
+        "redux": "3.7.2"
+      }
+    },
+    "@types/redux-mock-store": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@types/redux-mock-store/-/redux-mock-store-0.0.12.tgz",
+      "integrity": "sha512-DEIyiTllcmGfP3VjBnL+8sx3Tv63MITodkhL/vNig5fKtCI/vWkWurLKgrs/hUnj6wiUUPdUlALuIv8LUZN1Xg==",
+      "dev": true,
+      "requires": {
+        "redux": "3.7.2"
       }
     },
     "abab": {
@@ -4207,6 +4237,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
+    "lodash-es": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
+      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
@@ -6602,6 +6637,19 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-3.0.0.tgz",
       "integrity": "sha512-XzgvowFrwDo6TWcpJ/WTiarb9UI6lhA4PMzS7n1joK3sHfBBBOQHUc0U4u57D6DWO9vHv6lVSWx2Q/Ymfyv4hw=="
     },
+    "react-redux": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
+      "integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
+      "requires": {
+        "hoist-non-react-statics": "2.3.1",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4",
+        "lodash-es": "4.17.4",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.0"
+      }
+    },
     "react-router": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
@@ -6628,6 +6676,11 @@
         "react-router": "4.2.0",
         "warning": "3.0.0"
       }
+    },
+    "react-router-redux": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/react-router-redux/-/react-router-redux-4.0.8.tgz",
+      "integrity": "sha1-InQDWWtRUeGCN32rg1tdRfD4BU4="
     },
     "react-scripts-ts": {
       "version": "2.8.0",
@@ -6857,6 +6910,22 @@
       "requires": {
         "balanced-match": "0.4.2"
       }
+    },
+    "redux": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "requires": {
+        "lodash": "4.17.4",
+        "lodash-es": "4.17.4",
+        "loose-envify": "1.3.1",
+        "symbol-observable": "1.0.4"
+      }
+    },
+    "redux-mock-store": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.3.0.tgz",
+      "integrity": "sha512-TiwaDF4WLX/lJP0v1j4CMYUEfaIftTGuMUOYb7hmYJjLMAdgj2b/LOf+G9QDssNKFOpSl4B8St8TMUzF3hx92Q=="
     },
     "regenerate": {
       "version": "1.3.3",
@@ -7728,6 +7797,11 @@
         "path-to-regexp": "1.7.0",
         "serviceworker-cache-polyfill": "4.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
     },
     "symbol-tree": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,13 @@
   "dependencies": {
     "react": "^16.1.1",
     "react-dom": "^16.1.1",
+    "react-redux": "^5.0.6",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
-    "react-scripts-ts": "2.8.0"
+    "react-router-redux": "^4.0.8",
+    "react-scripts-ts": "2.8.0",
+    "redux": "^3.7.2",
+    "redux-mock-store": "^1.3.0"
   },
   "scripts": {
     "start": "react-scripts-ts start",
@@ -31,8 +35,11 @@
     "@types/node": "^8.0.53",
     "@types/react": "^16.0.25",
     "@types/react-dom": "^16.0.3",
+    "@types/react-redux": "^5.0.13",
     "@types/react-router": "^4.0.17",
     "@types/react-router-dom": "^4.2.1",
+    "@types/react-router-redux": "^5.0.10",
+    "@types/redux-mock-store": "0.0.12",
     "coveralls": "^3.0.0",
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-16": "^1.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,27 @@
 import * as React from 'react';
 import './App.css';
 
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+
 import { createBrowserHistory } from 'history';
 import { Link, Route, Router, Switch } from 'react-router-dom';
 
+import reducers from './reducers';
+
 import Home from './components/home';
 
+const store = createStore(reducers);
 const history = createBrowserHistory();
 
 class App extends React.Component {
   render() {
     return (
-      <div>
+      <Provider store={store} key="provider">
         <Router history={history}>
           <div>
             <header>
-              <h2>React / TS</h2>
+              <h2>React / TS / Redux</h2>
             </header>
             <main>
               <ul>
@@ -36,7 +42,7 @@ class App extends React.Component {
             </main>
           </div>
         </Router>
-      </div>
+      </Provider>
     );
   }
 }

--- a/src/actions/home.ts
+++ b/src/actions/home.ts
@@ -1,0 +1,5 @@
+import { createTypes } from '../core/redux';
+
+export const types = createTypes({
+  loading: undefined,
+}, { prefix: 'HOME' });

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,0 +1,1 @@
+export { types as homeTypes } from './home';

--- a/src/components/home/index.spec.tsx
+++ b/src/components/home/index.spec.tsx
@@ -1,57 +1,106 @@
-import Home, { Props, PropsWithRoute, State } from './';
+import Home, { Props, PropsDispatcher } from './';
 
 import { shallow, ShallowWrapper } from '../../specHelper';
+import configureMockStore from 'redux-mock-store';
+import { homeTypes } from '../../actions';
+
+const mockInitialState = {
+  homeReducer: {
+    loading: false,
+  },
+};
+
+let mockState = { ...mockInitialState };
+
+const mockStore = configureMockStore();
+const store = mockStore(() => mockState);
+
+const routerProps = {
+  match: {
+    params: {
+      name: 'brunolm',
+    },
+  },
+};
 
 describe('Home', () => {
-  let component: ShallowWrapper<Props & PropsWithRoute, State>;
+  let component: ShallowWrapper<Props & PropsDispatcher, any>;
 
   beforeEach(() => {
-    const routerProps = {
-      match: {
-        params: {
-          name: 'brunolm',
-        },
-      },
-    };
-
-    component = shallow(Home, { props: routerProps });
+    component = shallow(Home, { store, props: routerProps });
+  });
+  afterEach(() => {
+    mockState = { ...mockInitialState };
   });
 
   it('renders without crashing', () => {
     expect(component).toBeTruthy();
   });
 
-  it('toggles status on button click', () => {
-    const toggleStatusButton = component.find('.toggle-status');
-
-    expect(component.state().loading).toBeFalsy();
+  it('dispatches toggle status action on button click', () => {
+    const toggleStatusButton = component.dive().find('.toggle-status');
 
     toggleStatusButton.simulate('click');
 
-    expect(component.state().loading).toBeTruthy();
+    expect(store.getActions().some((action) => action.type === homeTypes.loading))
+      .toBeTruthy();
   });
 
   it('displays name value from url param', () => {
-    const nameTitle = component.find('h3.name-title');
+    const nameTitle = component.dive().find('h3.name-title');
 
     expect(nameTitle.text()).toBe('Hello brunolm');
   });
 
-  describe('', () => {
+  it('displays done message', () => {
+    const loadingMessage = component.dive().find('span.loading');
+
+    expect(loadingMessage.text()).toBe('Done.');
+  });
+
+  describe('renderLoading', () => {
+    let instance: Home;
+
     beforeEach(() => {
-      const routerProps = {
+      instance = component.dive().instance() as Home;
+    });
+
+    it('renders done message when not loading', () => {
+      const Loading = instance.renderLoading();
+      expect(Loading.props.children).toBe('Done.');
+    });
+
+    it('renders loading message', () => {
+      mockState.homeReducer.loading = true;
+      component = shallow(Home, { store, props: routerProps });
+      instance = component.dive().instance() as Home;
+
+      const Loading = instance.renderLoading();
+      expect(Loading.props.children).toBe('Loading...');
+    });
+  });
+
+  describe('when no params in url', () => {
+    beforeEach(() => {
+      const props = {
+        ...routerProps,
         match: {
+          ...routerProps.match,
           params: {
+            ...routerProps.match.params,
             name: undefined,
           },
         },
       };
 
-      component = shallow(Home, { props: routerProps });
+      component = shallow(Home, {
+        store,
+        props,
+      });
     });
 
-    it('displays "no name" when there are no values from url param', () => {
-      const nameTitle = component.find('h3.name-title');
+    it('displays "no name"', () => {
+      const nameTitle = component.dive().find('h3.name-title');
 
       expect(nameTitle.text()).toBe('Hello no name');
     });

--- a/src/components/home/index.tsx
+++ b/src/components/home/index.tsx
@@ -2,8 +2,22 @@ import './index.css';
 
 import * as React from 'react';
 
+import { Dispatch, connect } from 'react-redux';
+
+import { homeTypes } from '../../actions';
+
+const mapStateToProps = (state) => {
+  return {
+    ...state.homeReducer,
+  };
+};
+
+const mapDispatchToProps = (dispatch: Dispatch<any>) => ({
+  toggleLoading: (options) => dispatch({ type: homeTypes.loading, ...options }),
+});
+
 export interface Props {
-  something?: string;
+  loading: boolean;
 }
 export interface PropsWithRoute {
   match: {
@@ -12,44 +26,41 @@ export interface PropsWithRoute {
     };
   };
 }
-
-export interface State {
-  loading: boolean;
+export interface PropsDispatcher {
+  toggleLoading: (options: any) => void;
 }
 
-export default class Home extends React.Component<Props & PropsWithRoute, State> {
-  constructor(props) {
-    super(props);
+@(connect(mapStateToProps, mapDispatchToProps) as any)
+export default class Home extends React.Component<Props & PropsWithRoute & PropsDispatcher, {}> {
+  toggleStatus = () => {
+    const { loading } = this.props;
 
-    this.state = {
-      loading: false,
-    };
+    this.props.toggleLoading({
+      loading: !loading,
+    });
   }
 
-  toggleStatus = () => {
-    const { loading } = this.state;
+  renderLoading() {
+    const { loading } = this.props;
 
-    this.setState({ loading: !loading });
+    if (loading) {
+      return (<span className="loading active">Loading...</span>);
+    }
+
+    return (<span className="loading">Done.</span>);
   }
 
   render() {
     const { params } = this.props.match;
-    const { loading } = this.state;
-
     const name = params.name || 'no name';
 
     return (
-      <div>
+      <main>
         <h3 className="name-title">Hello {name}</h3>
         <button className="toggle-status" onClick={this.toggleStatus}>Toggle Status</button>
 
-        {loading &&
-          <span>Loading...</span>
-        }
-        {!loading &&
-          <span>Done.</span>
-        }
-      </div>
+        {this.renderLoading()}
+      </main>
     );
   }
 }

--- a/src/core/redux.spec.ts
+++ b/src/core/redux.spec.ts
@@ -1,0 +1,65 @@
+import { createReducer, createTypes } from './redux';
+
+describe('redux', () => {
+  describe('createReducer', () => {
+    it('throws if initialState is falsy', () => {
+      expect(() => createReducer(undefined, {})).toThrow('initialState is required');
+    });
+
+    it('returns a function to handle action types', () => {
+      const reducer = createReducer({}, {});
+
+      expect(reducer).toBeInstanceOf(Function);
+    });
+
+    describe('reducer handler', () => {
+      let reducer: (state, action) => any;
+
+      const mockActionTypes = { incrementFoo: 'INCREMENT_FOO' };
+      const mockState = Object.freeze({ foo: 1 });
+      const mockHandlers = {
+        [mockActionTypes.incrementFoo]: (state = mockState, action) => ({ ...mockState, foo: mockState.foo + 1 }),
+      };
+
+      beforeAll(() => {
+        reducer = createReducer(mockState, mockHandlers);
+      });
+
+      it('returns state unchanged if there is no action', () => {
+        const state = reducer(mockState, undefined);
+
+        expect(state).toEqual(mockState);
+      });
+
+      it('returns state unchanged if there is no action type', () => {
+        const state = reducer(mockState, {});
+
+        expect(state).toEqual(mockState);
+      });
+
+      it('returns state unchanged if there is no handler for action type', () => {
+        const state = reducer(mockState, { type: 'no handler' });
+
+        expect(state).toEqual(mockState);
+      });
+
+      it('returns state changed by handler for action type', () => {
+        const state = reducer(mockState, { type: mockActionTypes.incrementFoo });
+
+        expect(state).toEqual({ ...mockState, foo: mockState.foo + 1 });
+      });
+    });
+  });
+
+  describe('createTypes', () => {
+    it('returns a new object with same keys and values as a copy of the key', () => {
+      const types = createTypes({ foo: undefined });
+      expect(types.foo).toBe('foo');
+    });
+
+    it('returns a new object with same keys and values as a copy of the key with a prefix when specified', () => {
+      const types = createTypes({ foo: undefined }, { prefix: 'HOME' });
+      expect(types.foo).toBe('HOME_foo');
+    });
+  });
+});

--- a/src/core/redux.ts
+++ b/src/core/redux.ts
@@ -1,0 +1,29 @@
+export function createTypes<T>(obj: T, options?: { prefix: string; }) {
+  const keys = Object.keys(obj);
+  const getKey = (key: string) => options && options.prefix ? `${options.prefix}_${key}` : key;
+
+  const mapTypes = (types, key) => {
+    types[key] = getKey(key);
+    return types;
+  };
+  return keys.reduce(mapTypes, {}) as { [key in keyof T]: string };
+}
+
+export function createReducer<T>(
+  initialState: T,
+  handlers: { [key: string]: (state: T, action: any) => T; }
+) {
+  if (!initialState) {
+    throw new Error('initialState is required');
+  }
+
+  return (state = initialState, action) => {
+    if (!action || !action.type) {
+      return state;
+    }
+
+    const handler = handlers[action.type];
+
+    return handler ? handler(state, action) : state;
+  };
+}

--- a/src/reducers/home.spec.ts
+++ b/src/reducers/home.spec.ts
@@ -1,0 +1,37 @@
+import { loading, handlers, initialState } from './home';
+
+import { homeTypes } from '../actions';
+
+describe('homeReducer', () => {
+  describe('reducers', () => {
+    describe('loading', () => {
+      it('returns loading status false for initial state', () => {
+        const action = { type: homeTypes.loading };
+
+        expect(loading(undefined, action))
+          .toHaveProperty('loading', false);
+      });
+
+      it('returns loading status false', () => {
+        const action = { type: homeTypes.loading, loading: false };
+
+        expect(loading(initialState, action))
+          .toHaveProperty('loading', false);
+      });
+
+      it('returns loading status true', () => {
+        const action = { type: homeTypes.loading, loading: true };
+
+        expect(loading(initialState, action))
+          .toHaveProperty('loading', true);
+      });
+    });
+
+  });
+
+  describe('handlers', () => {
+    it('loading', () => {
+      expect(handlers[homeTypes.loading]).toEqual(loading);
+    });
+  });
+});

--- a/src/reducers/home.ts
+++ b/src/reducers/home.ts
@@ -1,0 +1,21 @@
+import { createReducer } from '../core/redux';
+import { homeTypes } from '../actions';
+
+export const initialState = {
+  loading: false,
+};
+
+export const loading = (state = initialState, action) => {
+  return {
+    ...state,
+    loading: action.loading,
+  };
+};
+
+export const handlers = {
+  [homeTypes.loading]: loading,
+};
+
+export default createReducer(initialState, {
+  ...handlers,
+});

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux';
+import homeReducer from './home';
+import { routerReducer as routing } from 'react-router-redux';
+
+export default combineReducers({
+  homeReducer,
+  routing,
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "noImplicitAny": false,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "experimentalDecorators": true
   },
   "exclude": [
     "node_modules",

--- a/tslint.json
+++ b/tslint.json
@@ -4,7 +4,6 @@
         "align": [
             true,
             "parameters",
-            "arguments",
             "statements"
         ],
         "ban": false,


### PR DESCRIPTION
Wrap your root component with the `Provider` component

```typescript
import { Provider } from 'react-redux';

<Provider store={store} key="provider">
```

The store is created with

```typescript
import { createStore } from 'redux';

const store = createStore(reducers);
```

Reducers is the combined reducers of your application

```typescript
import { combineReducers } from 'redux';
import { routerReducer as routing } from 'react-router-redux';

export default combineReducers({
  homeReducer,
  routing,
});
```

A reducer boils down to a function that takes a state and an action and return a new state

```typescript
const homeReducer = (state = initialState, action) => {
  return {
    ...state,
    something: action.something,
};
```

Your root components now have to be exported with a decorator (or a function call), example with decorator:

```typescript
const mapStateToProps = (state) => {
  return {
    ...state.homeReducer,
  };
};

const mapDispatchToProps = (dispatch: Dispatch<any>) => ({
  toggleLoading: (options) => dispatch({ type: homeTypes.loading, ...options }),
});

@(connect(mapStateToProps, mapDispatchToProps) as any)
```